### PR TITLE
Adding fixture.addJs method to add karma loaded scripts to the fixture

### DIFF
--- a/fixtures.js
+++ b/fixtures.js
@@ -34,6 +34,29 @@
             var cb = typeof arguments[arguments.length - 1] === 'function' ? arguments[arguments.length -1] : null;
             addToContainer(self.read.apply(self, arguments), cb);
         };
+        self.addJs = function(name, callback) {
+            var scripts = document.getElementsByTagName('script'),
+                head;
+
+            for (var i = 0; i < scripts.length; i++) {
+                var src = scripts[i].getAttribute('src');
+
+                if (src && src.indexOf(name) !== -1) {
+
+                    var doc = self.window().document;
+                    head = doc.getElementsByTagName('head')[0];
+
+                    var script = doc.createElement('script');
+                    script.type = 'text/javascript';
+                    script.async = true;
+                    script.onload = callback;
+                    script.src = src;
+                    head.appendChild(script);
+
+                    return;
+                }
+            }
+        };
         self.set = function(html){
             addToContainer(html);
         };


### PR DESCRIPTION
The method addJs can be used to add **karma loaded scripts** to the fixture iframe, right now any test util library you use in karma runs outside the fixture-iframe, this can be a problem sometimes.

For example, if you are using **sinon fake timers** to test some animation inside the fixture, you need to fake the Date object inside the fixture-iframe, and not the one in karma.

Usage:
```javascript
fixtures.load('AdSlotFixtureEmpty/AdSlotFixtureEmpty.html?wcmmode=disabled', function () {
 //... your fixture code ...
 fixtures.addJs("sinon", function() {
                _sinon = fixtures.window().sinon;
                clock = _sinon.useFakeTimers((new Date()).getTime());
            });
});
```
